### PR TITLE
added pip install using git for latest bug fixes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,15 @@ Install the full `ffmpegio` package via ``pip``:
 
    pip install ffmpegio
 
+or 
+
+for the latest development version: latest bug fixes and features
+requires git to be already installed.
+
+.. code-block:: bash
+
+    pip install git+https://github.com/python-ffmpegio/python-ffmpegio
+
 If `numpy.ndarray` data I/O is not needed, instead use 
 
 .. code-block:: bash


### PR DESCRIPTION
Added the Way to install from the pip using the GitHub in the documentation.
There are many advantages: -
  - Latest Developed Version
  - Latest Bug fixes
  - Latest Features

I tested the pip method works on the Windows & Linux.
It Only work when the git is Installed, I mentioned it above the command.